### PR TITLE
Use HTTPS URL during login and HTTP for other requests.

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -13,7 +13,8 @@ from myfitnesspal.meal import Meal
 
 
 class Client(MFPBase):
-    BASE_URL = 'https://www.myfitnesspal.com/'
+    BASE_URL = 'http://www.myfitnesspal.com/'
+    BASE_URL_SECURE = 'https://www.myfitnesspal.com/'
     LOGIN_PATH = 'account/login'
     ABBREVIATIONS = {
         'carbs': 'carbohydrates',
@@ -37,7 +38,7 @@ class Client(MFPBase):
             self._login()
 
     def _login(self):
-        login_url = os.path.join(self.BASE_URL, self.LOGIN_PATH)
+        login_url = os.path.join(self.BASE_URL_SECURE, self.LOGIN_PATH)
         document = self._get_document_for_url(login_url)
         authenticity_token = document.xpath(
             "(//input[@name='authenticity_token']/@value)[1]"


### PR DESCRIPTION
Requests.get method strips out extra parameters when URL is HTTPS, at
least in some situations/systems.
