### PR TITLE
Improve URL generation to not rely on os.sep

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -70,8 +70,8 @@ class Client(MFPBase):
     def _get_url_for_date(self, date, username):
         return os.path.join(
             self.BASE_URL,
-            'food/diary',
-            username,
+            'food/diary/',
+            username
         ) + '?date=%s' % (
             date.strftime('%Y-%m-%d')
         )


### PR DESCRIPTION
Specified the URL path separators directly rather than letting os.path.join insert its own separators.

Fixes #12 