### PR TITLE
Added keyring ability to Client to make login easier

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -13,6 +13,14 @@ from myfitnesspal.entry import Entry
 from myfitnesspal.meal import Meal
 
 
+try:
+    import keyring
+    keyring_installed = True
+except:
+    keyring_installed = False
+    pass
+
+
 class Client(MFPBase):
     BASE_URL = 'http://www.myfitnesspal.com/'
     BASE_URL_SECURE = 'https://www.myfitnesspal.com/'
@@ -30,8 +38,12 @@ class Client(MFPBase):
     }
 
     def __init__(self, username, password, login=True, unit_aware=False):
-        self.username = username
-        self.password = password
+        if keyring_installed:
+            self.username = username
+            self.password = keyring.get_password('myfitnesspal', username)
+        else:
+            self.username = username
+            self.password = password
         self.unit_aware = unit_aware
 
         self.session = requests.Session()


### PR DESCRIPTION
Hi there,

I added a little bit to `client.py` that will attempt to use the `python-keyring` library to get the password for the user. That way a new client can be created with
```python
client = myfitnesspal.Client('username', '')
```

and a password doesn't have to be stored in any scripts. If keyring isn't installed, it just falls back to the original behavior. I'm not sure if this is something that would be of interest to you or not, but I figured I'd send it along just in case.

To add your password to the keyring, you would do the following (one-time):
```python
import keyring
keyring.set_password('myfitnesspal', 'username', 'password')
```