### PR TITLE
Fix link to gitter

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -7,7 +7,7 @@ Do you track your eating habits on [MyFitnessPal](https://www.myfitnesspal.com/)
 
 Although MyFitnessPal [does have an API](https://www.myfitnesspal.com/api), it is private-access only; this creates an unnecessary barrier between you and your data that can be overcome using this library.
 
-Having problems? [Issues live on github](https://github.com/coddingtonbear/python-myfitnesspal/issues).  Have questions?  [Ask your questions in our gitter room](https://github.com/coddingtonbear/python-myfitnesspal/pull/17).
+Having problems? [Issues live on github](https://github.com/coddingtonbear/python-myfitnesspal/issues).  Have questions?  [Ask your questions in our gitter room](https://gitter.im/coddingtonbear/python-myfitnesspal).
 
 Installation
 ------------


### PR DESCRIPTION
The old link was to a pull request, not to Gitter. Maybe a bad copy+paste or something?