### PR TITLE
Fix to UK stone/pound measurements

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -425,9 +425,14 @@ class Client(MFPBase):
 
         # converts the date to a datetime object and the value to a float
         for date in measurements:
+
+            # replace 'st' with period to correctly convert UK stone/pounds
             temp_measurements[
                 datetime.datetime.strptime(date, '%m/%d/%Y').date()
-            ] = self._get_numeric(measurements[date], flt=True)
+            ] = self._get_numeric(
+                measurements[date].replace('st','.'),
+                flt=True
+            )
 
         measurements = temp_measurements
 


### PR DESCRIPTION
Hey there

Ignoring the fact that the UK stone/pound measurement is weird, they show up on the measurements page as (for example) '12 st 3 lbs'.  _get_numeric() currently transforms this to '123.0'.  This means there's no way to cleanly differentiate the two units without hacky logic in the client app (which gets particularly messy if a measurement is sub 10 stone.)

This is a quick and dirty stab at it, I put it in the call to _get_numeric() rather than _get_numeric() itself to reduce the risk of breaking any of the other callers.
