### PR TITLE
Remove whitespace from names as pulled from myfitnesspal.com

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -152,7 +152,7 @@ class Client(MFPBase):
         return result.json()['item']
 
     def _get_full_name(self, raw_name):
-        name = raw_name.lower()
+        name = raw_name.lower().strip()
         if name not in self.ABBREVIATIONS:
             return name
         return self.ABBREVIATIONS[name]


### PR DESCRIPTION
Fixes a recent issue on a change to the myfitnesspal.com site that is adding in whitespace around
names of totals and goals. Fixes issue #34 