### PR TITLE
Handle new "macro-value" span element in entries

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -241,7 +241,7 @@ class Client(MFPBase):
             except IndexError:
                 # This is the 'delete' button
                 continue
-            value = self._get_numeric(column.text)
+            value = self._extract_value(column)
             nutrition[nutr_name] = self._get_measurement(nutr_name, value)
 
         return nutrition
@@ -282,7 +282,9 @@ class Client(MFPBase):
                     except IndexError:
                         # This is the 'delete' button
                         continue
-                    value = self._get_numeric(column.text)
+                    
+                    value = self._extract_value(column)
+                    
                     nutrition[nutr_name] = self._get_measurement(
                         nutr_name,
                         value
@@ -303,6 +305,14 @@ class Client(MFPBase):
             )
 
         return meals
+
+    def _extract_value(self, element):
+        if len(element.getchildren()) == 0:
+            value = self._get_numeric(element.text)
+        else:
+            value = self._get_numeric(element.xpath("span[@class='macro-value']")[0].text)
+        
+        return value
 
     def get_date(self, *args, **kwargs):
         if len(args) == 3:

--- a/tests/html/diary.html
+++ b/tests/html/diary.html
@@ -209,7 +209,10 @@
                 <td>240</td>
                 
                 
-                <td>44</td>
+                <td>
+                    <span class="macro-value">44</span>
+                    <span class="macro-percentage">20</span>
+                </td>
                 
                 
                 <td>6</td>


### PR DESCRIPTION
Regular diary entries, and the goals entries, had a span element added
to support toggling views of %age based macro goals and raw nutrition values.

Adds support for getting the actual values from the table of a diary page.
Ignores the %age values but these could be implemented in future.

Also adds some span elements to the test page to ensure the changes work as
expected.