### PR TITLE
Fixed _get_numeric() with empty strings

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -209,7 +209,9 @@ class Client(MFPBase):
         return measure(**{kwarg: value})
 
     def _get_numeric(self, string, flt=False):
-        if flt:
+        if not string.strip():
+            return 0
+        elif flt:
             return float(re.sub(r'[^\d.]+', '', string))
         else:
             return int(re.sub(r'[^\d.]+', '', string))


### PR DESCRIPTION
Addresses symptom of #37. (Though, root cause is fixed by #36)

Still, I think it's reasonable that `_get_numeric()` not fail on missing data. Up to the maintainers if they want to merge this.