### PR TITLE
adds attributes 'quantity' 'unit' and 'short_name' to Entry class

### DIFF
--- a/myfitnesspal/entry.py
+++ b/myfitnesspal/entry.py
@@ -9,7 +9,7 @@ class Entry(MFPBase):
         self._nutrition = nutrition
         
         #split out quantity and measuring unit out of entry name
-        regex = r'(?P<short_name>.+), (?P<quantity>\d+.*) (?P<unit>\w+|serving\(s\))(?: \(.+\))?'
+        regex = r'(?P<short_name>.+), (?P<quantity>\d[\d\.]*) (?P<unit>[\w\(\)]+)(?: \(.*\))?'
         match = re.search(regex, name)
 
         self._quantity = None

--- a/myfitnesspal/entry.py
+++ b/myfitnesspal/entry.py
@@ -3,7 +3,6 @@ import re
 from myfitnesspal.base import MFPBase
 
 
-
 class Entry(MFPBase):
     def __init__(self, name, nutrition):
         self._name = name
@@ -17,7 +16,6 @@ class Entry(MFPBase):
         self._quantity = None
         self._unit = None
         self._short_name = None
-
         if match:
             self._quantity = match.group('quantity')
             self._unit = match.group('unit')

--- a/myfitnesspal/entry.py
+++ b/myfitnesspal/entry.py
@@ -7,8 +7,7 @@ class Entry(MFPBase):
     def __init__(self, name, nutrition):
         self._name = name
         self._nutrition = nutrition
-
-
+        
         #split out quantity and measuring unit out of entry name
         regex = r'(?P<short_name>.+), (?P<quantity>\d+.*) (?P<unit>\w+|serving\(s\))(?: \(.+\))?'
         match = re.search(regex, name)
@@ -20,7 +19,6 @@ class Entry(MFPBase):
             self._quantity = match.group('quantity')
             self._unit = match.group('unit')
             self._short_name = match.group('short_name')
-
 
     def __getitem__(self, value):
         return self.totals[value]
@@ -55,7 +53,9 @@ class Entry(MFPBase):
 
     @property
     def short_name(self):
-        return self._short_name.strip()
+        if self._short_name:
+            return self._short_name.strip()
+        return self._short_name
 
     @property
     def unit(self):

--- a/myfitnesspal/entry.py
+++ b/myfitnesspal/entry.py
@@ -1,5 +1,7 @@
-from myfitnesspal.base import MFPBase
 import re
+
+from myfitnesspal.base import MFPBase
+
 
 
 class Entry(MFPBase):
@@ -8,13 +10,18 @@ class Entry(MFPBase):
         self._nutrition = nutrition
 
 
-    #split out quantity and measuring unit out of entry name
+        #split out quantity and measuring unit out of entry name
         regex = r'(?P<short_name>.+), (?P<quantity>\d+.*) (?P<unit>\w+|serving\(s\))(?: \(.+\))?'
         match = re.search(regex, name)
 
-        self._quantity = match.group('quantity')
-        self._unit = match.group('unit')
-        self._short_name = match.group('short_name')
+        self._quantity = None
+        self._unit = None
+        self._short_name = None
+
+        if match:
+            self._quantity = match.group('quantity')
+            self._unit = match.group('unit')
+            self._short_name = match.group('short_name')
 
 
     def __getitem__(self, value):


### PR DESCRIPTION
split out 'quantity' and 'measuring unit' from entry name

example:
if entry.name is 'Alpro - Soy Milk: Unsweetened, 100 ml' returns the following:

entry.quantity = '100'
entry.unit = 'ml'
entry.short_name = 'Alpro - Soy Milk: Unsweetened'
 