### PR TITLE
Adding methods for extracting exercise data

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -13,6 +13,7 @@ from .day import Day
 from .entry import Entry
 from .keyring_utils import get_password_from_keyring
 from .meal import Meal
+from .exercise import Exercise
 from .note import Note
 
 
@@ -307,12 +308,134 @@ class Client(MFPBase):
 
         return meals
 
+    def _get_url_for_exercise(self, date, username):
+        return parse.urljoin(
+            self.BASE_URL,
+            'exercise/diary/' + username
+        ) + '?date=%s' % (
+            date.strftime('%Y-%m-%d')
+        )
+
+    def _get_exercise(self, document):
+        exercises = []
+        ex_headers = document.xpath("//table[@class='table0']")
+
+        for ex_header in ex_headers:
+            fields = []
+            tds = ex_header.findall('thead')[0].findall('tr')[0].findall('td')
+            ex_name = tds[0].text.lower()
+            if len(fields) == 0:
+                for field in tds:
+                    fields.append(
+                        self._get_full_name(
+                            field.text
+                        )
+                    )
+            # comment
+            row = ex_header.findall('tbody')[0].findall('tr')[0]
+            entries = []
+            while True:
+                # comment
+                if not row.attrib.get('class') is None:
+                    break
+                columns = row.findall('td')
+
+                # Cardio diary exercise descriptions are anchor tags
+                # within divs, but strength training exercise
+                # descriptions are just anchor tags within the td.
+
+                # But *first* we need to check whether an anchor
+                # tag exists, or we throw an error looking for
+                # an anchor tag within a div that doesn't exist
+
+                # check for `td > a`
+                if columns[0].find('a') is None:
+
+                    # check for `td > div > a`
+                    if columns[0].find('div').find('a') is None:
+                        # if neither, return `td.text`
+                        name = columns[0].text.strip()
+                    else:
+                        # otherwise return `td > div > a.text`
+                        name = columns[0].find('div').find('a').text.strip()
+                else:
+                    # otherwise, our first check for `td > a` will have passed
+                    name = columns[0].find('a').text.strip()
+
+                attrs = {}
+
+                for n in range(1, len(columns)):
+                    column = columns[n]
+                    try:
+                        attr_name = fields[n]
+                    except IndexError:
+                        # This is the 'delete' button
+                        continue
+
+                    if column.text is None:
+                        value = None
+                    else:
+                        value = self._get_numeric(column.text)
+
+                    attrs[attr_name] = self._get_measurement(
+                        attr_name,
+                        value
+                    )
+
+                entries.append(
+                    Entry(
+                        name,
+                        attrs,
+                    )
+                )
+                # comment
+                row = row.getnext()
+
+            exercises.append(
+                Exercise(
+                    ex_name,
+                    entries,
+                )
+            )
+
+        return exercises
+
+    def get_exercise(self, *args, **kwargs):
+        if len(args) == 3:
+            date = datetime.date(
+                int(args[0]),
+                int(args[1]),
+                int(args[2]),
+            )
+        elif len(args) == 1 and isinstance(args[0], datetime.date):
+            date = args[0]
+        else:
+            raise ValueError(
+                'get_exercise accepts either a single datetime or date instance, '
+                'or three integers representing year, month, and day '
+                'respectively.'
+            )
+
+        # get the exercise URL
+
+        document = self._get_document_for_url(
+            self._get_url_for_exercise(
+                date,
+                kwargs.get('username', self.effective_username)
+            )
+        )
+
+        # gather the exercise goals
+        exercise = self._get_exercise(document)
+
+        return exercise
+
     def _extract_value(self, element):
         if len(element.getchildren()) == 0:
             value = self._get_numeric(element.text)
         else:
             value = self._get_numeric(element.xpath("span[@class='macro-value']")[0].text)
-        
+
         return value
 
     def get_date(self, *args, **kwargs):

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -411,9 +411,9 @@ class Client(MFPBase):
             date = args[0]
         else:
             raise ValueError(
-                'get_exercise accepts either a single datetime or date instance, '
-                'or three integers representing year, month, and day '
-                'respectively.'
+                'get_exercise accepts either a single datetime '
+                'or date instance, or three integers representing '
+                'year, month, and day respectively.'
             )
 
         # get the exercise URL

--- a/myfitnesspal/exercise.py
+++ b/myfitnesspal/exercise.py
@@ -1,0 +1,31 @@
+from myfitnesspal.base import MFPBase
+
+
+class Exercise(MFPBase):
+    def __init__(self, name, entries):
+        self._name = name
+        self._entries = entries
+
+    def __getitem__(self, value):
+        if not isinstance(value, int):
+            raise ValueError('Index must be an integer')
+        return self.entries[value]
+
+    def __len__(self):
+        return len(self.entries)
+
+    @property
+    def entries(self):
+        return self._entries
+
+    @property
+    def name(self):
+        return self._name
+
+    def get_as_list(self):
+        return [e.get_as_dict() for e in self.entries]
+
+    def __unicode__(self):
+        return u'%s' % (
+            self.name.title()
+        )


### PR DESCRIPTION
- define class `Exercise`, an object containing exercise entries for each group of exercises (cardio & strength)
- define `_get_url_for_exercise`, an internal method for appending the baseURL to a specific user and date’s exercise diary
- define `_get_exercise`, an internal method for extracting cardio & strength training exercise data from a given user and date
- define `get_exercise`, a public method which returns an array of Exercise objects for a given user and date

**********

This is based off the proposed changes in PR #43 
I'm new to python development (I mostly use R & JS), so there may be some best practices not observed and methods I could have implemented better:
- I think the biggest room for improvement is better defining a class to return to the user.   
    - For example, there could be a calories_burnt total for the `Exercise` class. However, the differences between cardio and strength training disincentivized me from attempting this. 
- I thought about implementing something similar to the `Day` class as well, but it seemed unnecessary. 
- Finally, there is likely some redundancy in the methods, especially with `get_exercise`.