### PR TITLE
Added food search and item detail fetching functionality

### DIFF
--- a/myfitnesspal/fooditem.py
+++ b/myfitnesspal/fooditem.py
@@ -51,8 +51,8 @@ class FoodItem(MFPBase):
         return self._verified
 
     @property
-    def default_serving(self):
-        return self._default_serving
+    def serving(self):
+        return self._serving
 
     @property
     def calcium(self):

--- a/myfitnesspal/fooditem.py
+++ b/myfitnesspal/fooditem.py
@@ -55,6 +55,10 @@ class FoodItem(MFPBase):
         return self._serving
 
     @property
+    def calories(self):
+        return self._calories
+
+    @property
     def calcium(self):
         return self._calcium
 

--- a/myfitnesspal/fooditem.py
+++ b/myfitnesspal/fooditem.py
@@ -1,0 +1,133 @@
+from myfitnesspal.base import MFPBase
+
+
+class FoodItem(MFPBase):
+    def __init__(self, mfp_id, name, brand, verified, serving, calories,
+                 calcium=None, carbohydrates=None, cholesterol=None,
+                 fat=None, fiber=None, iron=None, monounsaturated_fat=None,
+                 polyunsaturated_fat=None, potassium=None, protein=None,
+                 saturated_fat=None, sodium=None, sugar=None, trans_fat=None,
+                 vitamin_a=None, vitamin_c=None, confirmations=None,
+                 servings=None):
+        self._mfp_id = mfp_id
+        self._name = name
+        self._brand = brand
+        self._verified = verified
+        self._serving = serving
+        self._calories = calories
+        self._calcium = calcium
+        self._carbohydrates = carbohydrates
+        self._cholesterol = cholesterol
+        self._fat = fat
+        self._fiber = fiber
+        self._iron = iron
+        self._monounsaturated_fat = monounsaturated_fat
+        self._polyunsaturated_fat = polyunsaturated_fat
+        self._potassium = potassium
+        self._protein = protein
+        self._saturated_fat = saturated_fat
+        self._sodium = sodium
+        self._sugar = sugar
+        self._trans_fat = trans_fat
+        self._vitamin_a = vitamin_a
+        self._vitamin_c = vitamin_c
+        self._confirmations = confirmations
+        self._servings = servings
+
+    @property
+    def mfp_id(self):
+        return self._mfp_id
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def brand(self):
+        return self._brand
+
+    @property
+    def verified(self):
+        return self._verified
+
+    @property
+    def default_serving(self):
+        return self._default_serving
+
+    @property
+    def calcium(self):
+        return self._calcium
+
+    @property
+    def carbohydrates(self):
+        return self._carbohydrates
+
+    @property
+    def cholesterol(self):
+        return self._cholesterol
+
+    @property
+    def fat(self):
+        return self._fat
+
+    @property
+    def fiber(self):
+        return self._fiber
+
+    @property
+    def iron(self):
+        return self._iron
+
+    @property
+    def monounsaturated_fat(self):
+        return self._monounsaturated_fat
+
+    @property
+    def polyunsaturated_fat(self):
+        return self._polyunsaturated_fat
+
+    @property
+    def potassium(self):
+        return self._potassium
+
+    @property
+    def protein(self):
+        return self._protein
+
+    @property
+    def saturated_fat(self):
+        return self._saturated_fat
+
+    @property
+    def sodium(self):
+        return self._sodium
+
+    @property
+    def sugar(self):
+        return self._sugar
+
+    @property
+    def trans_fat(self):
+        return self._trans_fat
+
+    @property
+    def vitamin_a(self):
+        return self._vitamin_a
+
+    @property
+    def vitamin_c(self):
+        return self._vitamin_c
+
+    @property
+    def confirmations(self):
+        return self._confirmations
+
+    @property
+    def servings(self):
+        return self._servings
+
+    def __unicode__(self):
+        return u'%s -- %s' % (
+            self.name,
+            self.brand
+        )

--- a/myfitnesspal/fooditemserving.py
+++ b/myfitnesspal/fooditemserving.py
@@ -1,0 +1,30 @@
+from myfitnesspal.base import MFPBase
+
+
+class FoodItemServing(MFPBase):
+    def __init__(self, serving_id, nutrition_multiplier, value, unit, index):
+        self._serving_id = serving_id
+        self._nutrition_multiplier = nutrition_multiplier
+        self._value = value
+        self._unit = unit
+        self._index = index
+
+    @property
+    def serving_id(self):
+        return self._serving_id
+
+    @property
+    def nutrition_multiplier(self):
+        return self._nutrition_multiplier
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def unit(self):
+        return self._unit
+
+    @property
+    def index(self):
+        return self._index

--- a/myfitnesspal/fooditemserving.py
+++ b/myfitnesspal/fooditemserving.py
@@ -28,3 +28,9 @@ class FoodItemServing(MFPBase):
     @property
     def index(self):
         return self._index
+
+    def __unicode__(self):
+        return u'%.2f x %s' % (
+            self.value,
+            self.unit
+        )

--- a/readme.markdown
+++ b/readme.markdown
@@ -189,6 +189,49 @@ weight
 
 Measurements are returned as ordered dictionaries. The first argument specifies the measurement name, which can be any name listed in the MyFitnessPal [Check-In](http://www.myfitnesspal.com/measurements/check_in/) page. When specifying a date range, the order of the date arguments does not matter.
 
+Food Search Examples
+--------------------
+
+To search for items:
+
+```python
+import myfitnesspal
+
+client = myfitnesspal.Client('my_username')
+
+food_items = client.get_food_search_results("bacon cheeseburger")
+food_items
+# >> [<Bacon Cheeseburger -- Sodexo Campus>,
+# <Junior Bacon Cheeseburger -- Wendy's>,
+# <Bacon Cheeseburger -- Continental Café>,
+# <Bacon Cheddar Cheeseburger -- Applebees>,
+# <Bacon Cheeseburger - Plain -- Homemade>,
+# <Jr. Bacon Cheeseburger -- Wendys>,
+# ...
+
+print("{} ({}), {}, cals={}, mfp_id={}".format(
+    food_items[0].name,
+    food_items[0].brand,
+    food_items[0].serving,
+    food_items[0].calories,
+    food_items[0].mfp_id
+))
+# > Bacon Cheeseburger (Sodexo Campus), 1 Sandwich, cals = 420.0
+```
+
+To get details for a particular food:
+```python
+import myfitnesspal
+
+client = myfitnesspal.Client('my_username')
+
+item = client.get_food_item_details("89755756637885")
+item.servings
+# > [<1.00 x Sandwich>]
+item.saturated_fat
+# > 10.0
+```
+
 Command-line API
 ----------------
 


### PR DESCRIPTION
This PR adds support for:

1. Searching for food items, using MFP's search for adding food items to the daily diary (modeled from desktop website);
2. Looking up a food item's details, using MFP's API, as is done by the desktop website when clicking "Nutrition Info" in search results.

