### PR TITLE
[#76] Ensure BRITISH_UNIT_MATCHER regex only matches strings with 'st'

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -22,7 +22,7 @@ from .fooditemserving import FoodItemServing
 
 logger = logging.getLogger(__name__)
 
-BRITISH_UNIT_MATCHER = re.compile(r'(?:(?P<st>\d+) st)?\W*(?:(?P<lbs>\d+) lb)?')
+BRITISH_UNIT_MATCHER = re.compile(r'(?:(?P<st>\d+) st)\W*(?:(?P<lbs>\d+) lb)?')
 
 
 class Client(MFPBase):


### PR DESCRIPTION
Fixes #76.