### PR TITLE
Travis CI: Upgrade to Python 3.6 because 3.4 is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
-sudo: false
 python:
     - "2.7"
-    - "3.4"
+    - "3.6"
 install:
     - pip install -q -e .
 script:


### PR DESCRIPTION
[Python 3.4 is now end of life](https://devguide.python.org/devcycle/#end-of-life-branches) 