### PR TITLE
_get_water now returns cups instead of milliliters like the Doumentation says

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -642,10 +642,10 @@ class Client(MFPBase):
             + "?date={date}".format(date=date.strftime("%Y-%m-%d"))
         )
         value = result.json()["item"]["milliliters"]
+        cups = int(Volume(ml=value).us_cup)
         if not self.unit_aware:
-            return value
-
-        return Volume(ml=value)
+            return cups
+        return Volume(us_cup=cups)
 
     def __str__(self) -> str:
         return f"MyFitnessPal Client for {self.effective_username}"


### PR DESCRIPTION
On the [readMe documentation](https://github.com/coddingtonbear/python-myfitnesspal/blob/master/readme.markdown) for getting your cups of water it says 

```
Or, if you just want to see how many cups of water you've recorded, or the notes you've entered for a day:

day.water
# >> 1
day.notes
# >> "This is the note I entered for this day"
```

However, as it stands, _get_water in the client returns the _millimeters_ of recorded, not the cups.

```
day.water
# >> 480 (2 cups recorded)
```

Therefore I would either update the readMe or change the client code like I've done in this pull request!

### New readMe:
```
Or, if you just want to see how many millimeters of water you've recorded, or the notes you've entered for a day:

day.water
# >> 240.0
day.notes
# >> "This is the note I entered for this day"
```

Obviously the readMe change is easy, but let me know if my code isn't good enough and I can try again. Thanks!! 