### PR TITLE
added fiber

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -44,6 +44,7 @@ class Client(MFPBase):
         "protein": (Mass, "g"),
         "sodium": (Mass, "mg"),
         "sugar": (Mass, "g"),
+	"fiber": (Mass, "g")
     }
 
     def __init__(self, username, password=None, login=True, unit_aware=False):


### PR DESCRIPTION
I noticed `fiber` was not pulled when pulling a day's nutrition values, example below. I attempted to add it by editing `client.py`. It was not immediately apparent to me that this might cause inconsistencies elsewhere. Very useful tool, thanks for making. 

```
day = client.get_date(2020, 6, 18)
day
```
<06/18/20 {'calories': 2253.0, 'carbohydrates': 335.0, 'fat': 68.0, 'protein': 62.0, 'sodium': 2763.0, 'sugar': 110.0}>


```
day.totals
```

{'calories': 2253.0,
 'carbohydrates': 335.0,
 'fat': 68.0,
 'protein': 62.0,
 'sodium': 2763.0,
 'sugar': 110.0}
