### PR TITLE
fixed measurement saving

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -578,6 +578,9 @@ class Client(MFPBase):
         # gather the IDs for all measurement types
         measurement_ids = self._get_measurement_ids(document)
 
+        # get the authenticity token for this edit
+        authenticity_token = document.xpath("(//form[@action='/measurements/new']/input[@name='authenticity_token']/@value)", smart_strings=False)[0]
+        
         # check if the measurement exists before going too far
         if measurement not in measurement_ids.keys():
             raise ValueError(f"Measurement '{measurement}' does not exist.")
@@ -587,7 +590,7 @@ class Client(MFPBase):
 
         # setup a dict for the post
         data = {
-            "authenticity_token": self._authenticity_token,
+            "authenticity_token": authenticity_token,
             "measurement[display_value]": value,
             "type": measurement_ids.get(measurement),
             "measurement[entry_date(2i)]": date.month,


### PR DESCRIPTION
this fixes #109.

the form for editing/inserting measurements requires a local field `authenticity_token` to be submitted in the request. the commit in this pull request queries the required value from the edit page's dom and inserts it into the request.

it thereby circumvents the `authenticity_token`  value stored during login time which evidently does not apply to the measurement adding request and changes everytime the measurement adding page is loaded.

it seems like using this measurement adding `authenticity_token` doesn't invalidate the login time `authenticity_token` since
```python
resp = client.set_measurements(value=50)
print(client.get_measurements())
```
appears to work fine. i'm guessing any POST operation requires a separate `authenticity_token` taken from the  respective page document's form as there are already provisions for this mechanism in `get_food_search_results()` as well as `_login()`.