### PR TITLE
146 fix get report datetime issue

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -748,13 +748,13 @@ class Client(MFPBase):
         if not data:
             return report_data
 
-        for index, entry in enumerate(json_data["data"]):
+        for index, entry in enumerate(data):
             # Dates are returned without year.
             # As the returned dates will always begin from the current day, the
-            # correct date can be determined using the entries index
+            # correct date can be determined using the entry's index
             date = (
-                datetime.datetime.today()
-                - datetime.timedelta(days=len(json_data["data"]))
+                datetime.date.today()
+                - datetime.timedelta(days=len(data))
                 + datetime.timedelta(days=index + 1)
             )
 

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -704,6 +704,9 @@ class Client(MFPBase):
         """
         Returns report data of a given name and category between two dates.
         """
+        if (datetime.date.today()-lower_bound).days > 80:
+            logger.warning(f"Report API may not be able to look back this far. Some results may be incorrect.")
+
         upper_bound, lower_bound = self._ensure_upper_lower_bound(
             lower_bound, upper_bound
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -438,31 +438,31 @@ class TestClient(MFPTestCase):
             True,
         )
 
-        def test_get_report(self):
-            with patch.object(self.client, "_get_json_for_url") as get_doc:
-                get_doc.return_value = self.get_json_data(
-                    "report_nutrition_net_calories.json"
-                )
-                actual_measurements = self.client.get_report(
-                    report_name="Net Calories",
-                    report_category="Nutrition",
-                    lower_bound=datetime.date.today() - datetime.timedelta(days=4),
-                )
-
-            # Dates are determined based on the assumption that the results will
-            # always start from the current day. Dates held in sample data file are
-            # therefore irrelevant for this test.
-
-            expected_measurements = OrderedDict(
-                sorted(
-                    [
-                        (datetime.date.today(), 425.0),
-                        (datetime.date.today() - datetime.timedelta(days=1), 1454.0),
-                        (datetime.date.today() - datetime.timedelta(days=2), 1451.0),
-                        (datetime.date.today() - datetime.timedelta(days=3), 1489.0),
-                        (datetime.date.today() - datetime.timedelta(days=4), 1390.0),
-                    ]
-                )
+    def test_get_report(self):
+        with patch.object(self.client, "_get_json_for_url") as get_doc:
+            get_doc.return_value = self.get_json_data(
+                "report_nutrition_net_calories.json"
+            )
+            actual_measurements = self.client.get_report(
+                report_name="Net Calories",
+                report_category="Nutrition",
+                lower_bound=datetime.date.today() - datetime.timedelta(days=4),
             )
 
-            self.assertEqual(expected_measurements, actual_measurements)
+        # Dates are determined based on the assumption that the results will
+        # always start from the current day. Dates held in sample data file are
+        # therefore irrelevant for this test.
+
+        expected_measurements = OrderedDict(
+            sorted(
+                [
+                    (datetime.date.today(), 425.0),
+                    (datetime.date.today() - datetime.timedelta(days=1), 1454.0),
+                    (datetime.date.today() - datetime.timedelta(days=2), 1451.0),
+                    (datetime.date.today() - datetime.timedelta(days=3), 1489.0),
+                    (datetime.date.today() - datetime.timedelta(days=4), 1390.0),
+                ]
+            )
+        )
+
+        self.assertEqual(expected_measurements, actual_measurements)


### PR DESCRIPTION
Fix datetime/date comparison issue reported in #146 
Note that the MFP report URL doesn't appear to return correct data if we're trying to look back too far. For example, `https://www.myfitnesspal.com/reports/results/nutrition/Net%20Calories/90.json` should return the last 90 days of net calories, but anything beyond 80 days is incorrect or zero for me.
I added a warning for this case.