### PR TITLE
Isolate execution flow for friend shared diary

### DIFF
--- a/docs/source/how_to/friends_diary_public.rst
+++ b/docs/source/how_to/friends_diary_public.rst
@@ -1,7 +1,7 @@
 Accessing a Friend’s Diary
 ==========================
 
-If a friend has their diary visibility set to public, you can grab their
+If a friend has their diary visibility set to "Public", you can grab their
 diary entries:
 
 .. code:: python

--- a/docs/source/how_to/friends_diary_shared.rst
+++ b/docs/source/how_to/friends_diary_shared.rst
@@ -1,0 +1,15 @@
+Accessing a Friend’s Diary (Shared)
+===================================
+
+If a friend has their diary visibility set to "Friends Only", you can grab their
+diary entries:
+
+.. code:: python
+
+   import myfitnesspal
+
+   client = myfitnesspal.Client()
+
+   friend_day = client.get_date(2020, 8, 23, friend_username="username_of_my_friend")
+   >>> friend_day
+   <08/23/20 {'calories': 891.0, 'carbohydrates': 105.0, 'fat': 38.0, 'protein': 29.0, 'sodium': 0.0, 'sugar': 2.0}>

--- a/docs/source/how_to/friends_diary_shared.rst
+++ b/docs/source/how_to/friends_diary_shared.rst
@@ -2,14 +2,53 @@ Accessing a Friend’s Diary (Shared)
 ===================================
 
 If a friend has their diary visibility set to "Friends Only", you can grab their
-diary entries:
+diary entries.
+
+To access a single day’s information:
 
 .. code:: python
 
-   import myfitnesspal
+    import myfitnesspal
 
-   client = myfitnesspal.Client()
+    client = myfitnesspal.Client()
 
-   friend_day = client.get_date(2020, 8, 23, friend_username="username_of_my_friend")
-   >>> friend_day
-   <08/23/20 {'calories': 891.0, 'carbohydrates': 105.0, 'fat': 38.0, 'protein': 29.0, 'sodium': 0.0, 'sugar': 2.0}>
+    friend_day = client.get_date(2020, 8, 23, friend_username="username_of_my_friend")
+
+    friend_day
+    # >> <03/02/13 {'sodium': 3326, 'carbohydrates': 369, 'calories': 2001, 'fat': 22, 'sugar': 103, 'protein': 110}>
+
+    friend_day.totals
+    # >> {'calories': 2001,
+    #     'carbohydrates': 369,
+    #     'fat': 22,
+    #     'protein': 110,
+    #     'sodium': 3326,
+    #     'sugar': 103}
+
+    friend_day.meals
+    # >> [<Breakfast {}>,
+    #    <Lunch {'sodium': 712, 'carbohydrates': 106, 'calories': 485, 'fat': 3, 'sugar': 0, 'protein': 17}>,
+    #    <Dinner {'sodium': 2190, 'carbohydrates': 170, 'calories': 945, 'fat': 11, 'sugar': 17, 'protein': 53}>,
+    #    <Snacks {'sodium': 424, 'carbohydrates': 93, 'calories': 571, 'fat': 8, 'sugar': 86, 'protein': 40}>]
+
+
+To access a week’s information with a loop on a date range:
+
+.. code:: python
+
+    import datetime
+
+    start_date = datetime.date(2023, 2, 18)
+    end_date = datetime.date(2023, 2, 25)
+
+    friend_shared_diary_data = []
+
+    for day in range(int((end_date - start_date).days)):
+        loop_year=((start_date + datetime.timedelta(day)).strftime("%Y"))
+        loop_month=((start_date + datetime.timedelta(day)).strftime("%m"))
+        loop_day=((start_date + datetime.timedelta(day)).strftime("%d"))
+        loop_pretty_date=str(start_date + datetime.timedelta(day))
+        diary_day_data = client.get_date(loop_year, loop_month, loop_day, friend_username="username_of_my_friend")
+        friend_shared_diary_data.append({loop_pretty_date: diary_day_data.totals})
+
+    print(friend_shared_diary_data)

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -147,6 +147,10 @@ class Client(MFPBase):
             "system_data",
             "profiles",
             "step_sources",
+            "privacy_preferences",
+            "social_preferences",
+            "app_preferences",
+            "partner_only_fields",
         ]
         query_string = parse.urlencode(
             [

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -497,8 +497,8 @@ class Client(MFPBase):
 
         # Since this data requires an additional request, let's just
         # allow the day object to run the request if necessary.
-        if 'friend_username' not in kwargs: notes = lambda: self._get_notes(date)  # noqa: E731
-        if 'friend_username' not in kwargs: water = lambda: self._get_water(date)  # noqa: E731
+        notes = lambda: self._get_notes(date)  # noqa: E731
+        water = lambda: self._get_water(date)  # noqa: E731
         if 'friend_username' not in kwargs:
             exercises = lambda: self._get_exercises(date)  # noqa: E731
         elif 'friend_username' in kwargs:

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -489,7 +489,9 @@ class Client(MFPBase):
             )
         )
         if "diary is locked with a key" in document.text_content():
-            raise Exception("Error: diary is locked with a key") 
+            raise Exception("Error: diary is locked with a key")
+        if kwargs.get("friend_username") is not None and "user maintains a private diary" in document.text_content():
+            raise Exception(f"Error: Friend {kwargs.get('friend_username')}'s diary is private.")
 
         meals = self._get_meals(document)
         goals = self._get_goals(document)

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -185,15 +185,12 @@ class Client(MFPBase):
 
     def _get_url_for_date(self, date: datetime.date, username: str, friend_username=None) -> str:
         if friend_username is not None:
-            date_str = date.strftime("%Y-%m-%d")
-            return (
-                parse.urljoin(self.BASE_URL_SECURE, "food/diary/" + friend_username)
-                + f"?date={date_str}"
-            )
+            name = friend_username
         else:
-            date_str = date.strftime("%Y-%m-%d")
-            return (
-                parse.urljoin(self.BASE_URL_SECURE, "food/diary/" + username)
+            name = username
+        date_str = date.strftime("%Y-%m-%d")
+        return (
+                parse.urljoin(self.BASE_URL_SECURE, "food/diary/" + name)
                 + f"?date={date_str}"
             )
 

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -511,8 +511,7 @@ class Client(MFPBase):
                 exercises=exercises,
                 complete=complete,
             )
-            return day
-        elif 'friend_username' in kwargs:
+        else:
             day = Day(
                 date=date,
                 meals=meals,
@@ -520,7 +519,7 @@ class Client(MFPBase):
                 exercises=exercises,
                 complete=complete,
             )
-            return day
+        return day
 
     def _ensure_upper_lower_bound(self, lower_bound, upper_bound):
         if upper_bound is None:

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -438,21 +438,16 @@ class Client(MFPBase):
 
     def _get_exercises(self, date: datetime.date, friend_username=None):
         if friend_username is not None:
-            # get the exercise URL
-            document = self._get_document_for_url(
-                self._get_url_for_exercise(date, friend_username)
-            )
-            # gather the exercise goals
-            exercise = self._get_exercise(document)
-            return exercise
+            name = friend_username
         else:
-            # get the exercise URL
-            document = self._get_document_for_url(
-                self._get_url_for_exercise(date, self.effective_username)
-            )
-            # gather the exercise goals
-            exercise = self._get_exercise(document)
-            return exercise
+            name = self.effective_username
+        # get the exercise URL
+        document = self._get_document_for_url(
+            self._get_url_for_exercise(date, name)
+        )
+        # gather the exercise goals
+        exercise = self._get_exercise(document)
+        return exercise
 
     def _extract_value(self, element):
         if len(element.getchildren()) == 0:

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -492,6 +492,8 @@ class Client(MFPBase):
                 date, kwargs.get("username", self.effective_username), kwargs.get("friend_username")
             )
         )
+        if "diary is locked with a key" in document.text_content():
+            raise Exception("Error: diary is locked with a key") 
 
         meals = self._get_meals(document)
         goals = self._get_goals(document)

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -499,10 +499,7 @@ class Client(MFPBase):
         # allow the day object to run the request if necessary.
         notes = lambda: self._get_notes(date)  # noqa: E731
         water = lambda: self._get_water(date)  # noqa: E731
-        if 'friend_username' not in kwargs:
-            exercises = lambda: self._get_exercises(date)  # noqa: E731
-        elif 'friend_username' in kwargs:
-            exercises = lambda: self._get_exercises(date, kwargs.get("friend_username"))  # noqa: E731
+        exercises = lambda: self._get_exercises(date, kwargs.get("friend_username"))  # noqa: E731
 
         if 'friend_username' not in kwargs:
             day = Day(


### PR DESCRIPTION
@coddingtonbear for your approval please find PR for:
Isolate execution flow for friend shared diary and data response, avoids potential confusion in PR #139 while providing clear instructions for friends with public access diaries or friends with private shared diaries. This addresses the requirement from both @JordanW94 and @hannahburkhardt in the referenced PR