### PR TITLE
Update requirements.txt for python3.13 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 blessed>=1.8.5,<2.0
-lxml>=4.2.5,<5
+lxml>=4.2.5
 measurement>=3.2.0,<4.0
 python-dateutil>=2.4,<3
 requests>=2.17.0,<3


### PR DESCRIPTION
`lxml<5` fails to build under python3.13 with an error as such: 

```
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      src/lxml/etree.c:270440:70: error: too few arguments to function call, expected 6, have 5
       270438 |                 int ret = _PyLong_AsByteArray((PyLongObject *)v,
              |                           ~~~~~~~~~~~~~~~~~~~
       270439 |                                               bytes, sizeof(val),
       270440 |                                               is_little, !is_unsigned);
              |                                                                      ^
      /usr/local/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/include/python3.13/cpython/longobject.h:111:17: note: '_PyLong_AsByteArray' declared here
        111 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
            |                 ^                   ~~~~~~~~~~~~~~~~
        112 |     unsigned char* bytes, size_t n,
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        113 |     int little_endian, int is_signed, int with_exceptions);
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      15 errors generated.
      Compile failed: command '/usr/bin/clang' failed with exit code 1
      creating var/folders/s4/k04s0q417w31pnl_mz49llgr0000gn/T
      cc -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/usr/include/libxml2 -c /var/folders/s4/k04s0q417w31pnl_mz49llgr0000gn/T/xmlXPathInitstnug_7x.c -o var/folders/s4/k04s0q417w31p
nl_mz49llgr0000gn/T/xmlXPathInitstnug_7x.o
      cc var/folders/s4/k04s0q417w31pnl_mz49llgr0000gn/T/xmlXPathInitstnug_7x.o -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lxml2 -o a.out
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for lxml
Failed to build lxml
```
The issue in question is only fixed as of the 5.0 release and above: https://github.com/lxml/lxml/commit/c18f89b84f9254d026aa5c52c81cc9b4c982a187

Alternatively, we could also version this package specifically for python==3.13 and >3.13 if there are other compatibility constraints that I'm not aware of here.

closes https://github.com/coddingtonbear/python-myfitnesspal/issues/187