### PR TITLE
Fix: 403 Forbidden on authentication

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -12,7 +12,6 @@ from typing import Any, cast, overload
 from urllib import parse
 
 import browser_cookie3
-import cloudscraper
 import lxml.html
 import requests
 from measurement.base import MeasureBase
@@ -79,7 +78,7 @@ class Client(MFPBase):
 
         self.unit_aware = unit_aware
 
-        self.session = cloudscraper.create_scraper(sess=requests.Session())
+        self.session = requests.Session()
         self.session.headers.update(
             {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ python-dateutil>=2.4,<3
 requests>=2.17.0,<3
 rich>=12,<13
 browser_cookie3>=0.16.1,<1
-cloudscraper>=1.2.71,<2
 typing-extensions==4.12.2


### PR DESCRIPTION
It appears that using cloudscraper is causing the 403 error described in issue #196, and removing it resolves the problem.

I tried to determine the exact cause, but even when using the same headers and cookies, a plain requests.Session() works while cloudscraper fails. The only differences I could identify were at the TCP level, where cloudscraper was sending some retransmission or duplicate packets.

I also tried upgrading cloudscraper to 3.0.0, but it didn't change a thing.