### PR TITLE
Fix: New API for saved meals and measurements

### DIFF
--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -12,7 +12,6 @@ from typing import Any, cast, overload
 from urllib import parse
 
 import browser_cookie3
-import cloudscraper
 import lxml.html
 import requests
 from measurement.base import MeasureBase
@@ -79,7 +78,7 @@ class Client(MFPBase):
 
         self.unit_aware = unit_aware
 
-        self.session = cloudscraper.create_scraper(sess=requests.Session())
+        self.session = requests.Session()
         self.session.headers.update(
             {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36"

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -675,16 +675,30 @@ class Client(MFPBase):
         if measurement not in measurement_ids.keys():
             raise ValueError(f"Measurement '{measurement}' does not exist.")
 
-        # build the update url.
-        update_url = parse.urljoin(self.BASE_URL_SECURE, "/api/services/incubator/measurements/upsert")
+        # Measurement update requests isn't the same depending on measurement type
+        if measurement == "Weight":
+            # build the update url.
+            update_url = parse.urljoin(self.BASE_URL_SECURE, "/api/services/incubator/measurements/upsert")
 
-        # setup JSON data for the put
-        json = {
-            "value": value,
-            "type": measurement_ids.get(measurement),
-            "unit": unit,
-            "entry_date": date.strftime("%Y-%m-%d"),
-        }
+            # setup JSON data for the put
+            json = { "item": {
+                "value": value,
+                "type": measurement.lower(),
+                "unit": unit,
+                "entry_date": date.strftime("%Y-%m-%d"),
+            }}
+        else:
+            # build the update url.
+            update_url = parse.urljoin(
+                self.BASE_URL_SECURE, "/api/user-measurements/measurements"
+            )
+
+            # for non-weight type, measurement should be sent in an array
+            json = { "items": [{
+                "value": value,
+                "type": measurement,  # first char uppercased for non-weight type
+                "date": date.strftime("%Y-%m-%d"),  # field renamed
+            }]}
 
         # now put it.
         result = self.session.put(update_url, json=json)

--- a/myfitnesspal/client.py
+++ b/myfitnesspal/client.py
@@ -1381,23 +1381,14 @@ class Client(MFPBase):
         Value: Meal Name
         """
         meals_dict = {}
-        meals_path = "meal/mine"
+        meals_path = "api/services/users/meals/mine?limit=100&search="
         meals_url = parse.urljoin(self.BASE_URL_SECURE, meals_path)
-        document = self._get_document_for_url(meals_url)
+        json = self._get_json_for_url(meals_url)
 
-        meals = document.xpath(
-            "//*[@id='matching']/li"
-        )  # get all items in the recipe list
-        _idx: int | None = None
-        try:
-            for _idx, meal in enumerate(meals):
-                meal_path = meal.xpath("./a")[0].attrib["href"]
-                meal_id = meal_path.split("/")[-1].split("?")[0]
-                meal_title = meal.xpath("./a")[0].text
-                meals_dict[meal_id] = meal_title
-        except Exception:
-            # no meals available?
-            logger.warning(f"Could not extract meal at index {_idx}")
+        for meal in json:
+            meal_id = meal["meal_id"]
+            meal_title = meal["description"]
+            meals_dict[meal_id] = meal_title
 
         return meals_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ python-dateutil>=2.4,<3
 requests>=2.17.0,<3
 rich>=12,<13
 browser_cookie3>=0.16.1,<1
-cloudscraper>=1.2.71,<2
 typing-extensions==4.12.2


### PR DESCRIPTION
`set_measurements`, `get_meals`, and `get_meal` were no longer working due to structural changes in the MyFitnessPal pages, which broke the web scraping methods previously used.

- `set_measurements` now performs a `PUT` request directly to the API.
- `get_meals` and `get_meal` now perform a `GET` request directly to the API.

Please note: this PR depends on #197, which repaired broken authentication. Client tests passed.